### PR TITLE
Update lib/src/objectory_query_builder.dart

### DIFF
--- a/lib/src/objectory_query_builder.dart
+++ b/lib/src/objectory_query_builder.dart
@@ -1,6 +1,7 @@
 library objectory_query;
 import 'package:mongo_dart/bson.dart';
 import 'objectory_base.dart';
+import 'dart:collection';
 
 class ObjectoryQueryBuilder {
   Map map;


### PR DESCRIPTION
The latest version of SDK has `LinkedHashMap` moved from `dart:core` to `dart:collection`.
