### PR TITLE
Update lib/src/persistent_object.dart

### DIFF
--- a/lib/src/persistent_object.dart
+++ b/lib/src/persistent_object.dart
@@ -3,6 +3,7 @@ import 'objectory_query_builder.dart';
 import 'package:mongo_dart/bson.dart';
 import 'objectory_base.dart';
 import 'dart:async';
+import 'dart:collection';
 part 'persistent_list.dart';
 
 


### PR DESCRIPTION
The latest version of SDK has `LinkedHashMap` moved from `dart:core` to `dart:collection`.
