### PR TITLE
Save and remove methods from Persitent object should return Future

### DIFF
--- a/lib/src/persistent_object.dart
+++ b/lib/src/persistent_object.dart
@@ -141,11 +141,11 @@ class PersistentObject extends BasePersistentObject{
     map["_id"] = null;
     super._initMap();
   }
-  remove() {
+  Future remove() {
     objectory.remove(this);
   }
-  save() {
-    objectory.save(this);
+  Future save() {
+    return objectory.save(this);
   }
   void setProperty(String property, value){
     super.setProperty(property,value);


### PR DESCRIPTION
I don't understand why save and remove methods from Persistant don't return Future, while those from objectory return it.
I think they should return because these methods are asynchronous
