### PR TITLE
Fix ObjectQueryBuilder.range when maxInclude=false

### DIFF
--- a/lib/src/objectory_query_builder.dart
+++ b/lib/src/objectory_query_builder.dart
@@ -138,7 +138,7 @@ class ObjectoryQueryBuilder {
       rangeMap["\$lte"] = max;
     }
     else{
-      rangeMap["\$gt"] = max;
+      rangeMap["\$lt"] = max;
     }
     map[propertyName] = rangeMap;
     return this;


### PR DESCRIPTION
It was generating gt instead of lt.
