### PR TITLE
Suggestion: add a clone() method

### DIFF
--- a/lib/src/objectory_query_builder.dart
+++ b/lib/src/objectory_query_builder.dart
@@ -58,4 +58,10 @@ class ObjectoryQueryBuilder extends SelectorBuilder{
   
   ObjectoryQueryBuilder references(String propertyName, PersistentObject model) => eq(propertyName, new DbRef(objectory.getCollectionByModel(model), model.id));
   ObjectoryQueryBuilder containsReference(String propertyName, PersistentObject model) => oneFrom(propertyName, [new DbRef(objectory.getCollectionByModel(model), model.id)]);
+  
+  ObjectoryQueryBuilder clone() {
+    var copy = where.eq('foo', 'bar');
+    copy.map = new Map.from(map);
+    return copy;
+  }
 }


### PR DESCRIPTION
I need cloning in so many places (I have a base query, and derive other queries from that).

Can we add something like this to the API?
